### PR TITLE
Installs keybase CLI binaries

### DIFF
--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -43,6 +43,7 @@ packages:
 - ca-certificates
 - curl
 - zsh
+- xz-utils
 - direnv
 - neovim
 - python-is-python3

--- a/src/packer/jumpbox-image.pkr.hcl
+++ b/src/packer/jumpbox-image.pkr.hcl
@@ -84,4 +84,9 @@ build {
     ]
   }
 
+  provisioner "shell" {
+    scripts = [
+      "${local.directories.source}/scripts/install-keybase.sh"
+    ]
+  }
 }

--- a/src/scripts/install-keybase.sh
+++ b/src/scripts/install-keybase.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S bash -e
+
+if [[ ! -f ${WORK_DIR}/keybase_amd64.deb ]] ; then
+  (cd ${WORK_DIR} && curl --silent --remote-name https://prerelease.keybase.io/keybase_amd64.deb)
+fi
+ar -p ${WORK_DIR}/keybase_amd64.deb data.tar.xz | 
+  xz --decompress | 
+  sudo tar -C / --strip-components 1 -xf - ./usr/bin/keybase ./usr/lib/systemd/user/keybase.service 


### PR DESCRIPTION
TL;DR
-----

Adds Keybase CLI installation to the template

Details
-------

Updates image creation so that the resulting image has `keybase` available as a command-line (only) tool. Keybase doesn't distribute a package without the GUI, so we had to improvise. The current approach uses a Packer provisioner to run a script that downloads the Keybase package and extracts only the CLI and systemd service files.

