### PR TITLE
Mounts the FCD for home directories

### DIFF
--- a/src/cloud-init/instance/user-data.yml
+++ b/src/cloud-init/instance/user-data.yml
@@ -29,6 +29,9 @@ network:
       wakeonlan: true
       dhcp4: true
 
+mounts:
+- [ sdb, /home ]
+
 users:
 - default
 - name: crdant


### PR DESCRIPTION
TL;DR
-----

Updates instance cloud-init to mount second disk at `/home`

Details
-------

Updates the user-data template for the jumpbox instance so that
the first-class disk is mounted at `/home` as part of running
cloud-init. This should enable preserving home directories across
Jumpbox rebuilds and facilitate a regular repaving practice in the
future.
