### PR TITLE
Fixes installation for Velero and Concourse CLIs

### DIFF
--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -75,8 +75,8 @@ runcmd:
   - curl -L https://carvel.dev/install.sh | bash
   - curl --output /usr/local/bin/mc -L https://dl.min.io/client/mc/release/linux-amd64/mc
   - chmod 755 /usr/local/bin/mc
-  - curl -L https://github.com/concourse/concourse/releases/download/v7.6.0/fly-7.6.0-linux-amd64.tgz | tar -C /usr/local/bin -xxf -
+  - curl -L https://github.com/concourse/concourse/releases/download/v7.6.0/fly-7.6.0-linux-amd64.tgz | tar -C /usr/local/bin -xzf -
   - curl --output /usr/local/bin/fission -L https://github.com/fission/fission/releases/download/v1.15.0/fission-v1.15.0-linux-amd64
   - chmod 755 /usr/local/bin/fission
-  - curl --output /usr/local/bin/velero -L https://github.com/vmware-tanzu/velero/releases/download/v1.7.1/velero-v1.7.1-linux-amd64.tar.gz
+  - curl -L https://github.com/vmware-tanzu/velero/releases/download/v1.7.1/velero-v1.7.1-linux-amd64.tar.gz | tar -xf /usr/local/bin --strip-components=1 velero-v1.7.1-linux-amd64/velero
   - chmod 755 /usr/local/bin/velero


### PR DESCRIPTION
TL;DR
-----

Repairs defects installing the Velero and Concourse CLIs

Details
-------

There were issues installing two tools, and this change fixes
them:

* Instead of the binary, the tarball for the Velero CLI was being
  installed at `/usr/local/bin/velero`
* A typo in the `tar` command when unpacking the `fly` CLI prevented
  it from being installed at all
