### PR TITLE
Replaces Docker with Podman

### DIFF
--- a/bin/prepare-params
+++ b/bin/prepare-params
@@ -13,4 +13,6 @@ ytt --ignore-unknown-comments -f ${SOURCE_DIR}/pipeline/params-template.yaml -f 
     --data-value github.pgp_key="$(curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
                                       gpg --keyring ${WORK_DIR}/key.gpg --no-default-keyring --import && gpg --keyring ${WORK_DIR}/key.gpg --no-default-keyring --export -a)" \
     --data-value github.repository="deb [arch=amd64] https://cli.github.com/packages stable main" \
+    --data-value kubic.pgp_key="$(curl --silent https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/Release.key)" \
+    --data-value kubic.repository="deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" \
   > ${WORK_DIR}/params.yaml

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -35,6 +35,9 @@ apt:
     github:
       source: #@ data.values.github.repository
       key: #@ data.values.github.pgp_key
+    kubic:
+      source: #@ data.values.kubic.repository
+      key: #@ data.values.kubic.pgp_key
 
 ## Update apt database and upgrade packages on first boot
 package_update: true

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -46,6 +46,7 @@ packages:
 - ca-certificates
 - curl
 - zsh
+- podman
 - xz-utils
 - direnv
 - neovim
@@ -69,7 +70,6 @@ snap:
   - snap install git-ubuntu --classic
   - snap install kubectl --classic
   - snap install helm --classic
-  - snap install docker
 
 runcmd:
   - curl -L https://carvel.dev/install.sh | bash

--- a/src/pipeline/params-template.yaml
+++ b/src/pipeline/params-template.yaml
@@ -21,3 +21,5 @@ microsoft:  #@ data.values.microsoft
 hashicorp: #@ data.values.hashicorp
 tailscale: #@ data.values.tailscale
 github: #@ data.values.github
+kubic: #@ data.values.kubic
+

--- a/src/pipeline/pipeline.yaml
+++ b/src/pipeline/pipeline.yaml
@@ -58,6 +58,7 @@ generate-user-data:
       HASHICORP_APT: ((hashicorp))
       TAILSCALE_APT: ((tailscale))
       GITHUB_CLI_APT: ((github))
+      KUBIC_APT: ((kubic))
     run:
       path: bash
       args:
@@ -72,6 +73,7 @@ generate-user-data:
             --data-value-yaml hashicorp="${HASHICORP_APT}" \
             --data-value-yaml tailscale="${TAILSCALE_APT}" \
             --data-value-yaml github="${GITHUB_CLI_APT}" \
+            --data-value-yaml kubic="${KUBIC_APT}" \
           >> user-data/user-data.yml
 
 packer-params: &packer-params

--- a/src/pipeline/pipeline.yaml
+++ b/src/pipeline/pipeline.yaml
@@ -31,6 +31,7 @@ resources:
 
 # - name: repave-timer
 #   type: time
+#   icon: timer-cog-outline
 #   source:
 #     start: 2:00 AM
 #     stop: 3:00 AM


### PR DESCRIPTION
TL;DR
-----

Installs `podman` instead of `docker`

Details
-------

Switches out Docker for Podman to avoid all the root-y stuff that
Docker depended upon. Removes the installation of the `docker`
Snap from the template and installs `podman` using Apt instead.
