### PR TITLE
Hardens and standardizes SSH config

### DIFF
--- a/bin/populate-vault
+++ b/bin/populate-vault
@@ -13,9 +13,16 @@ put-secret --team platform-team --pipeline "$(basename ${PROJECT_DIR})" \
 put-secret --team platform-team --pipeline "$(basename ${PROJECT_DIR})" \
   --var ssh_private_key value="$(cat $(yq e .ssh.private_key_file ${PARAMS_YAML}))" 
 
+ssh-keygen -t ed25519 -f ${SECRETS_DIR}/ssh_host_ed25519_key -N "" <<<y
+put-secret --team platform-team --pipeline "$(basename ${PROJECT_DIR})" \
+  --var ssh_host_key private="$(cat ${SECRETS_DIR}/ssh_host_ed25519_key)" \
+                     public="$(cat ${SECRETS_DIR}/ssh_host_ed25519_key.pub)"
+rm ${SECRETS_DIR}/ssh_host_ed25519_key ${SECRETS_DIR}/ssh_host_ed25519_key.pub
+
 put-secret --team platform-team \
   --var vsphere server="$(yq e .vsphere.server ${PARAMS_YAML})" username="$(yq e .vsphere.username ${PARAMS_YAML})@shortrib.local" \
                 host="$(yq e .vsphere.host ${PARAMS_YAML})" resource_pool="$(yq e .vsphere.resource_pool ${PARAMS_YAML})" \
                 password="$(yq e .vsphere.password ${PARAMS_YAML})" datacenter="$(yq e .vsphere.datacenter ${PARAMS_YAML})" \
                 cluster="$(yq e .vsphere.cluster ${PARAMS_YAML})" network="$(yq e .vsphere.network ${PARAMS_YAML})" \
                 datastore="$(yq e .vsphere.datastore ${PARAMS_YAML})" folder="$(yq e .vsphere.folder ${PARAMS_YAML})" 
+

--- a/src/cloud-init/instance/user-data.yml
+++ b/src/cloud-init/instance/user-data.yml
@@ -40,6 +40,7 @@ users:
   - users 
   - adm 
   - sudo
+  - ssher
   ssh_import_id: 
   - gh:crdant
   sudo: "ALL=(ALL) NOPASSWD:ALL"

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -82,7 +82,7 @@ groups:
   - ubuntu
 
 write_files:
-  path: /etc/ssh/sshd_config.d/01-hardening.conf
+- path: /etc/ssh/sshd_config.d/01-hardening.conf
   content: |
     # enable eed25519 key
     HostKey /etc/ssh/ssh_host_ed25519_key

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -102,9 +102,6 @@ write_files:
     PasswordAuthentication yes
     ChallengeResponseAuthentication no
     PubkeyAuthentication yes
-
-    # limit who can use SSH
-    AllowGroups ssher
   permissions: '0644'
   owner: root:root
 - path: /etc/ssh/sshd_config.d/88-gpg-forwarding.conf
@@ -132,7 +129,6 @@ write_files:
   owner: root:root
 
 runcmd:
-  - usermod -a -G ssher ubuntu 
   - curl -L https://carvel.dev/install.sh | bash
   - curl --output /usr/local/bin/mc -L https://dl.min.io/client/mc/release/linux-amd64/mc
   - chmod 755 /usr/local/bin/mc
@@ -142,4 +138,5 @@ runcmd:
   - curl -L https://github.com/vmware-tanzu/velero/releases/download/v1.7.1/velero-v1.7.1-linux-amd64.tar.gz | tar -C /usr/local/bin --strip-components=1 -xzf - velero-v1.7.1-linux-amd64/velero
   - chmod 755 /usr/local/bin/velero
   - rm /etc/ssh/ssh_host_dsa_key* /etc/ssh/ssh_host_ecdsa_key* /etc/ssh/ssh_host_rsa_key* 
-
+  - usermod -a -G ssher ubuntu 
+  - echo "# limit who can use SSH\nAllowGroups ssher" > /etc/ssh/ssh_config.d/02-limit-to-ssher.conf

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -127,6 +127,7 @@ write_files:
   owner: root:root
 
 runcmd:
+  - exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
   - curl -L https://carvel.dev/install.sh | bash
   - curl --output /usr/local/bin/mc -L https://dl.min.io/client/mc/release/linux-amd64/mc
   - chmod 755 /usr/local/bin/mc

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -140,7 +140,4 @@ runcmd:
   - chmod 755 /usr/local/bin/fission
   - curl -L https://github.com/vmware-tanzu/velero/releases/download/v1.7.1/velero-v1.7.1-linux-amd64.tar.gz | tar -C /usr/local/bin --strip-components=1 -xzf - velero-v1.7.1-linux-amd64/velero
   - chmod 755 /usr/local/bin/velero
-  - rm /etc/ssh/ssh_host_rsa_key*
-  - ssh-keygen -M generate -O bits=3072 /tmp/moduli.candidates
-  - ssh-keygen -M screen -f /tmp/moduli.candidates -f /tmp/moduli
-  - mv /tmp/moduli /etc/ssh/moduli
+  - rm /etc/ssh/ssh_host_rsa_key

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -14,9 +14,6 @@
 # configuration.
 fqdn: #@ "jumpbox.{}".format(data.values.domain)
 ssh_authorized_keys: #@ data.values.ssh.authorized_keys
-ssh_keys:
-  ed25519_private: #@ data.values.ssh_host_key.private
-  ed25519_public: #@ data.values.ssh_host_key.public
 
 ## don't require a password change since we just set it
 chpasswd:
@@ -82,6 +79,14 @@ groups:
   - ubuntu
 
 write_files:
+- path: /etc/ssh/ssh_host_ed25519_key
+  content: #@ data.values.ssh_host_key.private
+  permissions: '0644'
+  owner: root:root
+- path: /etc/ssh/ssh_host_ed25519_key.pub
+  content: #@ data.values.ssh_host_key.public
+  permissions: '0644'
+  owner: root:root
 - path: /etc/ssh/sshd_config.d/01-hardening.conf
   content: |
     # enable eed25519 key

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -99,7 +99,7 @@ write_files:
     HostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com
 
     # restrict authentication mechanism
-    PasswordAutehntication no
+    PasswordAuthentication no
     ChallengeResponseAuthentication no
     PubkeyAuthentication yes
 

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -127,7 +127,7 @@ write_files:
   owner: root:root
 
 runcmd:
-  - exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+  - usermod -a -G ssher ubuntu 
   - curl -L https://carvel.dev/install.sh | bash
   - curl --output /usr/local/bin/mc -L https://dl.min.io/client/mc/release/linux-amd64/mc
   - chmod 755 /usr/local/bin/mc
@@ -136,4 +136,5 @@ runcmd:
   - chmod 755 /usr/local/bin/fission
   - curl -L https://github.com/vmware-tanzu/velero/releases/download/v1.7.1/velero-v1.7.1-linux-amd64.tar.gz | tar -C /usr/local/bin --strip-components=1 -xzf - velero-v1.7.1-linux-amd64/velero
   - chmod 755 /usr/local/bin/velero
-  - rm /etc/ssh/ssh_host_rsa_key
+  - rm /etc/ssh/ssh_host_dsa_key* /etc/ssh/ssh_host_ecdsa_key* /etc/ssh/ssh_host_rsa_key* 
+

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -85,7 +85,7 @@ write_files:
 - path: /etc/ssh/sshd_config.d/01-hardening.conf
   content: |
     # enable eed25519 key
-    HostKey /etc/ssh/ssh_host_ed25519_key
+    # HostKey /etc/ssh/ssh_host_ed25519_key
 
     # restrict supported key exchange, cipher, and MAC algorithms
     KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256
@@ -94,7 +94,7 @@ write_files:
     HostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com
 
     # restrict authentication mechanism
-    PasswordAuthentication no
+    PasswordAuthentication yes
     ChallengeResponseAuthentication no
     PubkeyAuthentication yes
 

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -74,6 +74,63 @@ snap:
   - snap install kubectl --classic
   - snap install helm --classic
 
+groups:
+- ssher:
+  - ubuntu
+
+write_files:
+- path: /etc/ssh/ssh_host_ed25519_key
+  content: #@ data.values.ssh_host_key.private
+  permissions: '0400'
+  owner: root:root
+- path: /etc/ssh/ssh_host_ed25519_key.pub
+  content: #@ data.values.ssh_host_key.public
+  permissions: '0400'
+  owner: root:root
+- path: /etc/ssh/sshd_config.d/01-hardening.conf
+  content: |
+    # enable eed25519 key
+    HostKey /etc/ssh/ssh_host_ed25519_key
+
+    # restrict supported key exchange, cipher, and MAC algorithms
+    KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256
+    Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+    MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
+    HostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com
+
+    # restrict authentication mechanism
+    PasswordAutehntication no
+    ChallengeResponseAuthentication no
+    PubkeyAuthentication yes
+
+    # limit who can use SSH
+    AllowGroups ssher
+  permissions: '0644'
+  owner: root:root
+- path: /etc/ssh/sshd_config.d/88-gpg-forwarding.conf
+  content: |
+    # Enables automatic removal of stale sockets to support GPG forwarding
+    StreamLocalBindUnlink yes
+  permissions: '0644'
+  owner: root:root
+- path: /etc/ssh/ssh_config.d/01-hardening.conf
+  content: |
+    Host github.com
+      KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+    Host *
+      # restrict supported key exchange, cipher, and MAC algorithms
+      KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256
+      Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+      MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
+      HostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com
+
+      # restrict authentication mechanism
+      PasswordAuthentication no
+      ChallengeResponseAuthentication no
+      PubkeyAuthentication yes
+    permissions: '0644'
+  owner: root:root
+
 runcmd:
   - curl -L https://carvel.dev/install.sh | bash
   - curl --output /usr/local/bin/mc -L https://dl.min.io/client/mc/release/linux-amd64/mc
@@ -83,3 +140,7 @@ runcmd:
   - chmod 755 /usr/local/bin/fission
   - curl -L https://github.com/vmware-tanzu/velero/releases/download/v1.7.1/velero-v1.7.1-linux-amd64.tar.gz | tar -C /usr/local/bin --strip-components=1 -xzf - velero-v1.7.1-linux-amd64/velero
   - chmod 755 /usr/local/bin/velero
+  - rm /etc/ssh/ssh_host_rsa_key*
+  - ssh-keygen -M generate -O bits=3072 /tmp/moduli.candidates
+  - ssh-keygen -M screen -f /tmp/moduli.candidates -f /tmp/moduli
+  - mv /tmp/moduli /etc/ssh/moduli

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -85,7 +85,7 @@ write_files:
 - path: /etc/ssh/sshd_config.d/01-hardening.conf
   content: |
     # enable eed25519 key
-    # HostKey /etc/ssh/ssh_host_ed25519_key
+    HostKey /etc/ssh/ssh_host_ed25519_key
 
     # restrict supported key exchange, cipher, and MAC algorithms
     KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -104,7 +104,7 @@ write_files:
     PubkeyAuthentication yes
 
     # limit who can use SSH
-    # AllowGroups ssher
+    AllowGroups ssher
   permissions: '0644'
   owner: root:root
 - path: /etc/ssh/sshd_config.d/88-gpg-forwarding.conf

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -82,7 +82,7 @@ groups:
   - ubuntu
 
 write_files:
- path: /etc/ssh/sshd_config.d/01-hardening.conf
+  path: /etc/ssh/sshd_config.d/01-hardening.conf
   content: |
     # enable eed25519 key
     HostKey /etc/ssh/ssh_host_ed25519_key

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -138,5 +138,7 @@ runcmd:
   - curl -L https://github.com/vmware-tanzu/velero/releases/download/v1.7.1/velero-v1.7.1-linux-amd64.tar.gz | tar -C /usr/local/bin --strip-components=1 -xzf - velero-v1.7.1-linux-amd64/velero
   - chmod 755 /usr/local/bin/velero
   - rm /etc/ssh/ssh_host_dsa_key* /etc/ssh/ssh_host_ecdsa_key* /etc/ssh/ssh_host_rsa_key* 
+  - awk '$5 >= 3071' /etc/ssh/moduli > /etc/ssh/moduli.safe
+  - mv /etc/ssh/moduli.safe /etc/ssh/moduli
   - usermod -a -G ssher ubuntu 
   - echo "# limit who can use SSH\nAllowGroups ssher" > /etc/ssh/ssh_config.d/02-limit-to-ssher.conf

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -14,6 +14,9 @@
 # configuration.
 fqdn: #@ "jumpbox.{}".format(data.values.domain)
 ssh_authorized_keys: #@ data.values.ssh.authorized_keys
+ssh_keys:
+  ed25519_private: #@ data.values.ssh_host_key.private
+  ed25519_public: #@ data.values.ssh_host_key.public
 
 ## don't require a password change since we just set it
 chpasswd:
@@ -79,15 +82,7 @@ groups:
   - ubuntu
 
 write_files:
-- path: /etc/ssh/ssh_host_ed25519_key
-  content: #@ data.values.ssh_host_key.private
-  permissions: '0400'
-  owner: root:root
-- path: /etc/ssh/ssh_host_ed25519_key.pub
-  content: #@ data.values.ssh_host_key.public
-  permissions: '0400'
-  owner: root:root
-- path: /etc/ssh/sshd_config.d/01-hardening.conf
+ path: /etc/ssh/sshd_config.d/01-hardening.conf
   content: |
     # enable eed25519 key
     HostKey /etc/ssh/ssh_host_ed25519_key
@@ -104,7 +99,7 @@ write_files:
     PubkeyAuthentication yes
 
     # limit who can use SSH
-    AllowGroups ssher
+    # AllowGroups ssher
   permissions: '0644'
   owner: root:root
 - path: /etc/ssh/sshd_config.d/88-gpg-forwarding.conf

--- a/src/packer/jumpbox-image.pkr.hcl
+++ b/src/packer/jumpbox-image.pkr.hcl
@@ -40,7 +40,7 @@ source "vsphere-clone" "jumpbox-template" {
     images = false
     force = true
 
-    output_directory  var.output_directory
+    output_directory  = var.output_directory
   }
 }
 

--- a/src/packer/jumpbox-image.pkr.hcl
+++ b/src/packer/jumpbox-image.pkr.hcl
@@ -40,12 +40,18 @@ source "vsphere-clone" "jumpbox-template" {
     images = false
     force = true
 
-    output_directory = var.output_directory
+    output_directory  var.output_directory
   }
 }
 
 build {
   sources = ["source.vsphere-clone.jumpbox-template"]
+
+  provisioner "shell-local" {
+    inline = [
+      "sleep 60"
+    ]
+  }
 
   provisioner "shell" {
     inline = [

--- a/src/packer/jumpbox-image.pkr.hcl
+++ b/src/packer/jumpbox-image.pkr.hcl
@@ -47,12 +47,6 @@ source "vsphere-clone" "jumpbox-template" {
 build {
   sources = ["source.vsphere-clone.jumpbox-template"]
 
-  provisioner "shell-local" {
-    inline = [
-      "sleep 60"
-    ]
-  }
-
   provisioner "shell" {
     inline = [
       "cloud-init status --wait",

--- a/src/pipeline/pipeline.yaml
+++ b/src/pipeline/pipeline.yaml
@@ -51,7 +51,7 @@ generate-user-data:
     - name: user-data
     params:
       OVF_NAME: ((template.vm_name))
-      SSH_PRIVATE_KEY: ((ssh_private_key))
+      SSH_HOST_KEY: ((ssh_host_key))
       DOMAIN: ((domain))
       PASSWORD: ((password))
       SSH: ((ssh))
@@ -70,6 +70,7 @@ generate-user-data:
             --data-value domain=${DOMAIN} \
             --data-value hashed_password="$(echo ${PASSWORD} | openssl passwd -6 -salt $(openssl rand -base64 16) -stdin)" \
             --data-value-yaml ssh="${SSH}" \
+            --data-value-yaml ssh_host_key="${SSH_HOST_KEY}" \
             --data-value-yaml microsoft="${MICROSOFT_APT}" \
             --data-value-yaml hashicorp="${HASHICORP_APT}" \
             --data-value-yaml tailscale="${TAILSCALE_APT}" \
@@ -142,6 +143,7 @@ jobs:
           output_directory=${PWD}/template/${OVF_NAME}
           ssh_key=${PWD}/ssh.key
 
+          umask 077
           echo "${SSH_PRIVATE_KEY}" > ${ssh_key}
           packer validate --var project_root=${project_root} \
               --var ssh_private_key_file=${ssh_key} \
@@ -181,7 +183,9 @@ jobs:
           output_directory=${PWD}/template/${OVF_NAME}
           ssh_key=${PWD}/ssh.key
 
+          umask 077
           echo "${SSH_PRIVATE_KEY}" > ${ssh_key}
+          PACKER_LOG=yes
           packer build --var project_root=${project_root} \
               --var ssh_private_key_file=${ssh_key} \
               --var "user_data=$(cat user-data/user-data.yml)" \


### PR DESCRIPTION
TL;DR
-----

Makes SSH more secure and predictable

Details
-------

Hardens the SSH configuration of the jumpbox, both client and
server. Also re-uses the SSH host key to facilitate repaving on
a regular basis without the new key appearing suspect.

Uses tips from the following sources

* [SSH Hardening Guides](https://www.sshaudit.com/hardening_guides.html#ubuntu_20_04_lts)
* [Secure Secure Shell](https://stribika.github.io/2015/01/04/secure-secure-shell.html)

for hardening advice. Only users in the group `ssher` are allowed
in, and they must use an ED25519 key.
