### PR TITLE
Adds certbot to the Jumpbox image

### DIFF
--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -80,6 +80,9 @@ snap:
   - snap install git-ubuntu --classic
   - snap install kubectl --classic
   - snap install helm --classic
+  - snap install certbot --classic
+  - snap install certbot --classic
+  - snap install certbot-dns-google
 
 groups:
 - ssher


### PR DESCRIPTION
TL;DR
-----

Installs Certbot snap when building the jumpbox image

Details
-------

Enables a shift from using my laptop for Certbot to the Jumpbox
by installing Certbot on the Jumpbox.
