### PR TITLE
Switches to nerdctl from docker and podman

### DIFF
--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -45,11 +45,7 @@ packages:
 - open-vm-tools
 - ca-certificates
 - curl
-- docker-ce
-- docker-ce-rootless-extras
 - zsh
-- docker-ce
-- podman
 - xz-utils
 - direnv
 - neovim
@@ -64,6 +60,7 @@ packages:
 - silversearcher-ag
 - sipcalc
 - skopeo
+- containerd.io
 
 # install snaps on first boot
 snap:
@@ -133,6 +130,13 @@ write_files:
   owner: root:root
 
 runcmd:
+- |
+  bash -c "(
+    set -x
+    cd "$(mktemp -d)"
+    wget -O nerdctl.tar.gz -q $(curl -s https://api.github.com/repos/containerd/nerdctl/releases/latest | yq '.assets[] | select(.browser_download_url | test(".*full.*-linux-amd64.tar.gz$")).browser_download_url')
+    tar -C /usr/local -tzvf nerdctl.tar.gz
+  )"
 - curl https://kots.io/install | bash
 - |
   bash -c "(

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -60,6 +60,7 @@ packages:
 - silversearcher-ag
 - sipcalc
 - skopeo
+- rootlesskit
 
 # install snaps on first boot
 snap:

--- a/src/cloud-init/template/user-data.yml
+++ b/src/cloud-init/template/user-data.yml
@@ -60,7 +60,6 @@ packages:
 - silversearcher-ag
 - sipcalc
 - skopeo
-- containerd.io
 
 # install snaps on first boot
 snap:
@@ -135,7 +134,7 @@ runcmd:
     set -x
     cd "$(mktemp -d)"
     wget -O nerdctl.tar.gz -q $(curl -s https://api.github.com/repos/containerd/nerdctl/releases/latest | yq '.assets[] | select(.browser_download_url | test(".*full.*-linux-amd64.tar.gz$")).browser_download_url')
-    tar -C /usr/local -tzvf nerdctl.tar.gz
+    tar -C /usr/local -xzvf nerdctl.tar.gz
   )"
 - curl https://kots.io/install | bash
 - |

--- a/src/pipeline/params-template.yaml
+++ b/src/pipeline/params-template.yaml
@@ -22,6 +22,5 @@ hashicorp: #@ data.values.hashicorp
 tailscale: #@ data.values.tailscale
 github: #@ data.values.github
 docker: #@ data.values.docker
-gcloud: #@ data.values.gcloud
 
 tanzu: #@ data.values.tanzu

--- a/src/pipeline/pipeline.yaml
+++ b/src/pipeline/pipeline.yaml
@@ -59,7 +59,6 @@ generate-user-data:
       TAILSCALE_APT: ((tailscale))
       GITHUB_CLI_APT: ((github))
       DOCKER_APT: ((docker))
-      GCLOUD_APT: ((gcloud))
       TANZU: ((tanzu))
     run:
       path: bash
@@ -76,7 +75,6 @@ generate-user-data:
             --data-value-yaml tailscale="${TAILSCALE_APT}" \
             --data-value-yaml github="${GITHUB_CLI_APT}" \
             --data-value-yaml docker="${DOCKER_APT}" \
-            --data-value-yaml gcloud="${GCLOUD_APT}" \
             --data-value-yaml tanzu="${TANZU}" \
           >> user-data/user-data.yml
 


### PR DESCRIPTION
TL;DR
-----

Prepares for using `nerdctl` for local container tasks

Details
-------

Shifts the installed commands and daemons for working locally with containers from the previous approach using both `podman` and `docker`. The approach of installing both Podman and Docker came from an evolution toward Podman over Docker, but it was inconsistent with how I work on local systems where I use Rancher Desktop. By switching containerd with the `nerdctl` on the jumpbox I now have a consistent CLI between my local machines and my jumpbox.

Also cleans up some lingering setup from using RPM for Google Cloud.